### PR TITLE
Fix security warnings on GitHub Actions

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -20,6 +20,11 @@ on:
       - 'CHANGELOG.md'
       - 'LICENSE'
 
+# Default permissions
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   job1_Call_Build_and_Deploy:
     name: Build ${{ github.repository }}

--- a/.github/workflows/unleash.yml
+++ b/.github/workflows/unleash.yml
@@ -23,6 +23,11 @@ on:
 #    tags:
 #      - '*'
 
+# Default permissions
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   # Deploy next snapshot
   job1_Call_Unleash:


### PR DESCRIPTION
- build_and_deploy.yml, unleash.yml:
  - add (explicit) default permissions:
    - contents: read
    - pull-requests: write

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration workflows to define default GitHub Actions permissions at the workflow level (contents: read; pull-requests: write).
  * Preserved existing job-level permission overrides where already specified.
  * No changes to triggers, job structure, or individual steps.
  * Applies across multiple workflows to standardize permission settings.
  * No user-facing impact or product behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->